### PR TITLE
Cleanup for the Supermarket, and linting issues

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,16 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-14.04
+  - name: ubuntu-16.04
+  - name: centos-7
+
+suites:
+  - name: default
+    run_list:
+      - recipe[godns]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2018 Leo Unbekandt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Install godns monitoring tool
 Requirements
 ------------
 
+### Platforms
+
+### Chef
+
+### Cookbooks
+
 None, this is Go !
 
 Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,43 +1,43 @@
 
-default["godns"] = {
-  "download_url" => "https://github.com/Scalingo/godns/releases/download/",
-  "version" => "v1.3",
-  "arch" => "amd64",
-  "install_path" => "/usr/local/bin",
-  "config_path" => "/etc/godns.conf",
+default['godns'] = {
+  'download_url' => 'https://github.com/Scalingo/godns/releases/download/',
+  'version' => 'v1.3',
+  'arch' => 'amd64',
+  'install_path' => '/usr/local/bin',
+  'config_path' => '/etc/godns.conf',
   # If default_dns is set, it copies /etc/resolv.conf to node['godns']['resolv_conf']
   # and changes /etc/resolv.conf in order to use 127.0.0.1
-  "default_dns" => false,
-  "default_resolv_host" => "127.0.0.1",
+  'default_dns' => false,
+  'default_resolv_host' => '127.0.0.1',
 
-  "debug" => false,
-  "host" => "127.0.0.1",
-  "port" => 53,
+  'debug' => false,
+  'host' => '127.0.0.1',
+  'port' => 53,
 
-  "resolv" => {
-    "file" => "/etc/resolv.conf.godns",
-    "timeout" => 5,
-    "setedns0" => true,
+  'resolv' => {
+    'file' => '/etc/resolv.conf.godns',
+    'timeout' => 5,
+    'setedns0' => true,
   },
-  "redis" => {
-    "url" => "redis://127.0.0.1:6379"
+  'redis' => {
+    'url' => 'redis://127.0.0.1:6379',
   },
-  "log" => {
-    "stdout" => true,
-    "file" => "",
-    "level" => "INFO",
+  'log' => {
+    'stdout' => true,
+    'file' => '',
+    'level' => 'INFO',
   },
-  "cache" => {
-    "backend" => "memory",
-    "expire" => 600,
-    "maxcount" => 0
+  'cache' => {
+    'backend' => 'memory',
+    'expire' => 600,
+    'maxcount' => 0,
   },
-  "hosts" => {
-    "enable" => true,
-    "file" => "/etc/hosts",
-    "redis_enable" => true,
-    "redis_key" => "godns:hosts",
-    "ttl" => 600,
-    "refresh_interval" => 5,
-  }
+  'hosts' => {
+    'enable' => true,
+    'file' => '/etc/hosts',
+    'redis_enable' => true,
+    'redis_key' => 'godns:hosts',
+    'ttl' => 600,
+    'refresh_interval' => 5,
+  },
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,3 +5,5 @@ license          'MIT'
 description      'Install GoDNS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.3.4'
+issues_url 'https://github.com/Scalingo/godns-cookbook/issues'
+source_url 'https://github.com/Scalingo/godns-cookbook'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,14 +9,14 @@
 
 require 'resolv'
 
-dirname = "godns-" +
-           node['godns']['version'] + "-linux-" +
-           node['godns']['arch']
+dirname = 'godns-' +
+          node['godns']['version'] + '-linux-' +
+          node['godns']['arch']
 archive = "#{dirname}.tar.gz"
 
 download_url =
-  node['godns']['download_url'] + "/" +
-  node['godns']['version'] + "/" + archive
+  node['godns']['download_url'] + '/' +
+  node['godns']['version'] + '/' + archive
 
 archive_dest_path = "#{Chef::Config[:file_cache_path]}/#{archive}"
 dir_dest_path = "#{Chef::Config[:file_cache_path]}/#{dirname}"
@@ -25,7 +25,7 @@ remote_file archive_dest_path do
   source download_url
 end
 
-bash "extract godns #{node['godns']['version'] }" do
+bash "extract godns #{node['godns']['version']}" do
   code <<-EOH
     tar -C #{Chef::Config[:file_cache_path]} -xvf #{archive_dest_path}
     cp #{dir_dest_path}/godns #{node['godns']['install_path']}
@@ -37,49 +37,49 @@ end
 template node['godns']['config_path'] do
   source 'godns.conf.erb'
   mode 06640
-  notifies :restart, "service[godns]", :delayed
+  notifies :restart, 'service[godns]', :delayed
 end
 
-binary_path = File.join(node['godns']['install_path'], "godns")
+binary_path = File.join(node['godns']['install_path'], 'godns')
 
 manager = Chef::Provider::Service::Upstart
 
-if node['init_package'] == "systemd"
+if node['init_package'] == 'systemd'
   manager = Chef::Provider::Service::Systemd
-  systemd_unit "godns.service" do
+  systemd_unit 'godns.service' do
     action :create
     systemd_content = {
-      "Unit" => {
-        "Description" => "GoDNS - DNS server backed by redis",
-        "After" => "network.target"
+      'Unit' => {
+        'Description' => 'GoDNS - DNS server backed by redis',
+        'After' => 'network.target',
       },
-      "Service" => {
-        "ExecStart" => "#{binary_path} -c #{node['godns']['config_path']}",
-        "Restart" => "always",
-        "RestartSec" => "30s",
-      }
+      'Service' => {
+        'ExecStart' => "#{binary_path} -c #{node['godns']['config_path']}",
+        'Restart' => 'always',
+        'RestartSec' => '30s',
+      },
     }
     content systemd_content
   end
 else
-  template "/etc/init/godns.conf" do
+  template '/etc/init/godns.conf' do
     source 'godns.init.conf.erb'
     mode 0664
-    variables({
-      target: binary_path,
-    })
-    notifies :stop, "service[godns]", :delayed
-    notifies :start, "service[godns]", :delayed
+    variables(
+      target: binary_path
+    )
+    notifies :stop, 'service[godns]', :delayed
+    notifies :start, 'service[godns]', :delayed
   end
 end
 
-bash "setup godns as default dns" do
+bash 'setup godns as default dns' do
   code <<-EOH
     cp /etc/resolv.conf #{node['godns']['resolv']['file']}
     echo -e "nameserver #{node['godns']['default_resolv_host']}\n" > /etc/resolv.conf
   EOH
   only_if do
-    node['godns']['default_dns'] and not File.exists?(node['godns']['resolv']['file'])
+    node['godns']['default_dns'] && !File.exist?(node['godns']['resolv']['file'])
   end
 end
 
@@ -88,4 +88,3 @@ service 'godns' do
   subscribes :restart, "remote_file[#{archive_dest_path}]"
   action [:enable, :start]
 end
-


### PR DESCRIPTION
* Added a kitchen.yml configuration to test platforms. Couldn't determine which platforms were
 supported to update metadata as both centos and ubuntu failed with the unit file. It'd be helpful
 to understand which version of chef you are targeting this to work for to understand what
 resources are usable.
* Added the MIT license
* Added headings to README for platform and chef information so that it's explicit about what is
 used. I don't know what should go here so I left them blank, but helpful to know what these are.
* Cleaned up rubocop errors based off of cookstyle reports (a pinned rubocop) that's helpful across
* community cookbooks to standardize on acceptable ruby conventions.
* Cleaned up foodcritic errors. Remaining:

FC066: Ensure chef_version is set in metadata: ./metadata.rb:1
FC067: Ensure at least one platform supported in metadata: ./metadata.rb:1

